### PR TITLE
Avoid "magic lists" in code

### DIFF
--- a/lib/Perl6/Documentable.pm6
+++ b/lib/Perl6/Documentable.pm6
@@ -3,6 +3,9 @@ unit module Perl6::Documentable;
 #| Enum to classify all "kinds" of Perl6::Documentable
 enum Kind is export <Type Language Programs Syntax Reference Routine>;
 
+#| List of the subdirectories that contain indexable pods by default
+constant DOCUMENTABLE-DIRS is export = ["Language", "Type", "Programs", "Native"];
+
 #| Everything documented inherits from this classed
 class Perl6::Documentable {
 

--- a/lib/Perl6/Documentable/CLI.pm6
+++ b/lib/Perl6/Documentable/CLI.pm6
@@ -99,7 +99,7 @@ package Perl6::Documentable::CLI {
         my $registry = Perl6::Documentable::Registry.new(
             :$cache,
             :$topdir,
-            :dirs(["Language", "Type", "Programs", "Native"]),
+            :dirs( DOCUMENTABLE-DIRS ),
             :verbose($v)
         );
         $registry.compose;
@@ -211,7 +211,7 @@ package Perl6::Documentable::CLI {
         # update the registry
         my $registry = Perl6::Documentable::Registry.new(
             :$topdir,
-            :dirs(["Language", "Type", "Programs", "Native"]),
+            :dirs(DOCUMENTABLE-DIRS),
             :!verbose,
         );
         $registry.compose;


### PR DESCRIPTION
If something is constant, it should probably be in a variable and given a name. 